### PR TITLE
Use PIE to build the binaries

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -25,7 +25,8 @@ do
         binary_extension=".exe"
     fi
     echo "Building ${supported_arch}…"
-    GOOS="$os" GOARCH="$arch" CGO_ENABLED=0 go build -trimpath \
+    GOOS="$os" GOARCH="$arch" CGO_ENABLED=0 go build -trimpath -mod=readonly \
+        -buildmode=pie \
         -ldflags="-X github.com/LeSuisse/vault-gpg-plugin/version.GitCommit='$(git rev-parse HEAD)'" \
         -o "pkg/${os}_${arch}/vault-gpg-plugin${binary_extension}"
 done


### PR DESCRIPTION
Not that useful in this context but at least it keeps people running
checksec without discernment at bay.