### PR TITLE
Error on create duplicate key

### DIFF
--- a/gpg/path_keys.go
+++ b/gpg/path_keys.go
@@ -5,13 +5,14 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"io"
+	"strings"
+
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 	"golang.org/x/crypto/openpgp"
 	"golang.org/x/crypto/openpgp/armor"
 	"golang.org/x/crypto/openpgp/packet"
-	"io"
-	"strings"
 )
 
 func pathListKeys(b *backend) *framework.Path {
@@ -191,6 +192,14 @@ func (b *backend) pathKeyCreate(ctx context.Context, req *logical.Request, data 
 	exportable := data.Get("exportable").(bool)
 	generate := data.Get("generate").(bool)
 	key := data.Get("key").(string)
+
+	resp, err := b.pathKeyRead(ctx, req, data)
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), nil
+	}
+	if resp != nil {
+		return logical.ErrorResponse("key already exists"), nil
+	}
 
 	var buf bytes.Buffer
 	switch generate {

--- a/gpg/path_keys_test.go
+++ b/gpg/path_keys_test.go
@@ -2,8 +2,9 @@ package gpg
 
 import (
 	"context"
-	"github.com/hashicorp/vault/sdk/logical"
 	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
 )
 
 func TestGPG_CreateNotGeneratedKeyWithoutKeyError(t *testing.T) {
@@ -50,6 +51,36 @@ func TestGPG_CreateErrorGeneratedKeyWithInvalidKey(t *testing.T) {
 	}
 	if !response.IsError() {
 		t.Fatal("Key was not a ASCII-armored key but has been created")
+	}
+}
+
+func TestGPG_CreateErrorGeneratedDuplicateKey(t *testing.T) {
+	storage := &logical.InmemStorage{}
+
+	b := Backend()
+
+	req := &logical.Request{
+		Storage:   storage,
+		Operation: logical.UpdateOperation,
+		Path:      "keys/test",
+		Data:      map[string]interface{}{},
+	}
+	response, err := b.HandleRequest(context.Background(), req)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.IsError() {
+		t.Fatal("Key was not created")
+	}
+
+	response, err = b.HandleRequest(context.Background(), req)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !response.IsError() {
+		t.Fatal("Duplicate key has been created")
 	}
 }
 


### PR DESCRIPTION
Prevent overwrite when creating key with same name as an existing key.

Signed-off-by: Trishank Karthik Kuppusamy <trishank.kuppusamy@datadoghq.com>