### PR TITLE
Add a config path to update key settings

### DIFF
--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -8,6 +8,7 @@ Since it is possible to mount secret backends at any location, please update you
 * [List Keys](#list-keys)
 * [Delete Key](#delete-key)
 * [Export Key](#export-key)
+* [Update Key Configuration](#update-key-configuration)
 * [Decrypt Data](#decrypt-data)
 * [Sign Data](#sign-data)
 * [Verify Signed Data](#verify-signed-data)
@@ -40,7 +41,7 @@ it must be deleted first.
 
 - `exportable` `(bool: false)` – Specifies if the raw key is exportable.
 
-- `transparency_log_address` `(string: "")` – Specifies the [Rekor transparency log](https://github.com/sigstore/rekor) address to publish the signature.
+- `transparency_log_address` `(string: "")` – Specifies the [Rekor transparency log](https://github.com/sigstore/rekor) address used to publish the signatures.
 
 ### Sample Payload
 
@@ -192,6 +193,40 @@ $ curl \
     "key": "-----BEGIN PGP PRIVATE KEY BLOCK-----\n\nxcLYBFmZ7JwBCACxsatS8MKxvKpMspkl7ck4vvgZvijBu0sx7Z0+0QDAj8ej5gfK\n...\nYsnjj4QHSRbwJVs/WSIiAj39EyD+bQZDDDFqg62pUA==\n=j7B6\n-----END PGP PRIVATE KEY BLOCK-----"
   }
 }
+```
+
+## Update Key Configuration
+
+This endpoint allows tuning configuration values for a given key.
+(These values are returned during a read operation on the named key.)
+
+
+| Method | Path                     | Produces           |
+|:-------|:-------------------------|:-------------------|
+| `POST` | `/gpg/keys/:name/config` | `204 (empty body)` |
+
+### Parameters
+
+- `name` `(string: <required>)` – Specifies the name of the key configure.
+
+- `transparency_log_address` `(string: "")` – Specifies the [Rekor transparency log](https://github.com/sigstore/rekor) address used to publish the signatures.
+
+### Sample payload
+
+```json
+{
+  "transparency_log_address": "https://rekor.example.com"
+}
+```
+
+### Sample request
+
+```
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request POST \
+    --data @payload.json \
+    https://vault.example.com/v1/gpg/keys/my-key/config
 ```
 
 ## Sign Data

--- a/gpg/backend.go
+++ b/gpg/backend.go
@@ -30,6 +30,7 @@ func Backend() *backend {
 			pathVerify(&b),
 			pathDecrypt(&b),
 			pathShowSessionKey(&b),
+			pathConfig(&b),
 		},
 		PathsSpecial: &logical.Paths{
 			SealWrapStorage: []string{

--- a/gpg/path_config.go
+++ b/gpg/path_config.go
@@ -1,0 +1,65 @@
+package gpg
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/locksutil"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func pathConfig(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: "keys/" + framework.GenericNameRegex("name") + "/config",
+		Fields: map[string]*framework.FieldSchema{
+			"name": {
+				Type:        framework.TypeString,
+				Description: "Name of the key",
+			},
+
+			"transparency_log_address": {
+				Type:        framework.TypeString,
+				Description: "Address of a Rekor transparency log to publish the signatures.",
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathConfigWrite,
+			},
+		},
+		HelpSynopsis:    pathConfigHelpSyn,
+		HelpDescription: pathConfigHelpDesc,
+	}
+}
+
+func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	name := data.Get("name").(string)
+
+	lock := locksutil.LockForKey(b.keyLocks, name)
+	lock.Lock()
+	defer lock.Unlock()
+
+	entry, err := b.key(ctx, req.Storage, name)
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return logical.ErrorResponse(fmt.Sprintf("no existing key named %s could be found", name)), logical.ErrInvalidRequest
+	}
+
+	persistNeeded := false
+	logAddress, ok := data.GetOk("transparency_log_address")
+	if ok {
+		entry.TransparencyLogAddress = logAddress.(string)
+		persistNeeded = true
+	}
+
+	if !persistNeeded {
+		return nil, nil
+	}
+
+	return &logical.Response{}, b.storeKeyEntry(ctx, req.Storage, name, entry)
+}
+
+const pathConfigHelpSyn = "Configure a named GPG key"
+const pathConfigHelpDesc = "This path is used to configure the named key."

--- a/gpg/path_config_test.go
+++ b/gpg/path_config_test.go
@@ -1,0 +1,88 @@
+package gpg
+
+import (
+	"context"
+	"github.com/hashicorp/vault/sdk/logical"
+	"testing"
+)
+
+func TestGPG_SetKeyConfig(t *testing.T) {
+	storage := &logical.InmemStorage{}
+	b := Backend()
+
+	req := &logical.Request{
+		Storage:   storage,
+		Operation: logical.UpdateOperation,
+		Path:      "keys/test",
+		Data: map[string]interface{}{
+			"real_name": "Vault",
+			"email":     "vault@example.com",
+			"key_bits":  2048,
+			"generate":  true,
+		},
+	}
+	_, err := b.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	updateTransparencyLogAddress := func(keyName string, address string) {
+		req := &logical.Request{
+			Storage:   storage,
+			Operation: logical.UpdateOperation,
+			Path:      "keys/" + keyName + "/config",
+			Data: map[string]interface{}{
+				"transparency_log_address": address,
+			},
+		}
+		_, err := b.HandleRequest(context.Background(), req)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	checkTransparencyLogAddress := func(keyName string, expectedAddress string) {
+		req := &logical.Request{
+			Storage:   storage,
+			Operation: logical.ReadOperation,
+			Path:      "keys/" + keyName,
+		}
+		resp, err := b.HandleRequest(context.Background(), req)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		respLogAddress := resp.Data["transparency_log_address"]
+
+		if respLogAddress != expectedAddress {
+			t.Errorf("no received the expected address %s, got %s", expectedAddress, respLogAddress)
+		}
+	}
+
+	checkTransparencyLogAddress("test", "")
+	updateTransparencyLogAddress("test", "https://rekor.example.com")
+	checkTransparencyLogAddress("test", "https://rekor.example.com")
+	updateTransparencyLogAddress("test", "")
+	checkTransparencyLogAddress("test", "")
+}
+
+func TestGPG_AttemptToSetConfigOfAnUnknownKey(t *testing.T) {
+	storage := &logical.InmemStorage{}
+	b := Backend()
+
+	req := &logical.Request{
+		Storage:   storage,
+		Operation: logical.UpdateOperation,
+		Path:      "keys/test/config",
+		Data: map[string]interface{}{
+			"transparency_log_address": "",
+		},
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected an error because the key does not exist")
+	}
+	if !resp.IsError() {
+		t.Fatal("expected an response error because the key does not exist")
+	}
+}

--- a/gpg/path_keys.go
+++ b/gpg/path_keys.go
@@ -237,18 +237,19 @@ func (b *backend) pathKeyCreate(ctx context.Context, req *logical.Request, data 
 		}
 	}
 
-	entry, err := logical.StorageEntryJSON("key/"+name, &keyEntry{
+	return nil, b.storeKeyEntry(ctx, req.Storage, name, &keyEntry{
 		SerializedKey:          buf.Bytes(),
 		Exportable:             exportable,
 		TransparencyLogAddress: transparencyLogAddress,
 	})
+}
+
+func (b *backend) storeKeyEntry(ctx context.Context, storage logical.Storage, name string, keyEntry *keyEntry) error {
+	entry, err := logical.StorageEntryJSON("key/"+name, keyEntry)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	if err := req.Storage.Put(ctx, entry); err != nil {
-		return nil, err
-	}
-	return nil, nil
+	return storage.Put(ctx, entry)
 }
 
 func (b *backend) pathKeyDelete(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {


### PR DESCRIPTION
This path can be used to update the transparency log address of existing keys.