### PR TITLE
Simplify signing step

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,26 +43,11 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 signs:
-  - id: binary-keyless
+  - id: cosign-keyless
     signature: "${artifact}.bundle"
     cmd: cosign
     args: ["sign-blob", "--bundle", "${signature}", "--yes", "${artifact}"]
-    artifacts: binary
-  - id: checksum-keyless
-    signature: "${artifact}.bundle"
-    cmd: cosign
-    args: ["sign-blob", "--bundle", "${signature}", "--yes", "${artifact}"]
-    artifacts: checksum
-  - id: sbom-keyless
-    signature: "${artifact}.bundle"
-    cmd: cosign
-    args: ["sign-blob", "--bundle", "${signature}", "--yes", "${artifact}"]
-    artifacts: sbom
-  - id: packages-keyless
-    signature: "${artifact}.bundle"
-    cmd: cosign
-    args: ["sign-blob", "--bundle", "${signature}", "--yes", "${artifact}"]
-    artifacts: package
+    artifacts: all
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 release:


### PR DESCRIPTION
We now ask goreleaser to sign everything it can. This make the whole thing easier and we are less likely to forget something.