### PR TITLE
Fix path of the binary checksum file

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,7 +38,7 @@ archives:
       - LICENSE
       - docs/*
       - src: "{{ .ArtifactPath }}.sha256sum"
-        dst: /
+        dst: .
         strip_parent: true
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
It should not be written to the absolute directory `/`.

See #314